### PR TITLE
build commonjs & esm packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,18 +2,23 @@
   "name": "@oceanprotocol/react",
   "version": "0.0.15",
   "description": "React hooks & components on top of squid.js",
-  "main": "dist/index.js",
+  "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
+  "react-native": "dist/esm/index.js",
   "scripts": {
     "start": "tsc --watch",
     "start-example": "cd example && npm start",
-    "build": "tsc",
-    "test": "npm run lint",
+    "watch": "tsc --watch",
+    "build": "rm -rf dist && npm run build:cjs && npm run build:esm",
+    "build:cjs": "tsc",
+    "build:esm": "tsc --module esNext --outDir dist/esm",
+    "test": "npm run lint && npm run type-check",
     "lint": "eslint --ignore-path .eslintignore --ext .js --ext .ts --ext .tsx .",
     "format": "prettier --ignore-path .gitignore './**/*.{css,yml,js,ts,tsx,json}' --write",
     "release": "release-it --non-interactive",
     "changelog": "auto-changelog -p",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "type-check": "tsc --noEmit"
   },
   "files": [
     "LICENSE",

--- a/src/providers/OceanProvider/OceanProvider.tsx
+++ b/src/providers/OceanProvider/OceanProvider.tsx
@@ -1,4 +1,10 @@
-import React, { useContext, useState, useEffect, createContext } from 'react'
+import React, {
+  useContext,
+  useState,
+  useEffect,
+  createContext,
+  ReactElement
+} from 'react'
 import Web3 from 'web3'
 import ProviderStatus from './ProviderStatus'
 import { Ocean, Logger, Account, Config } from '@oceanprotocol/lib'
@@ -27,7 +33,7 @@ function OceanProvider({
 }: {
   config: Config
   children: any
-}) {
+}): ReactElement {
   const [web3, setWeb3] = useState<Web3 | undefined>()
   const [web3Provider, setWeb3Provider] = useState<any | undefined>()
   const [ocean, setOcean] = useState<Ocean | undefined>()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,17 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es5",
-    "lib": ["es2015", "dom"],
     "moduleResolution": "node",
-    "outDir": "dist",
+    "target": "es5",
+    "lib": ["esnext", "dom"],
+    "outDir": "dist/cjs",
     "jsx": "react",
     "esModuleInterop": true,
     "sourceMap": true,
     "declaration": true,
-    "strictNullChecks": false
+    "strictNullChecks": false,
+    "noEmitOnError": true
   },
-  "include": ["./src/@types", "./src/index.ts"],
+  "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "example"]
 }


### PR DESCRIPTION
Change build outputs to generate CommonJS & ES modules individually, only use `tsc` for it.