### PR TITLE
liquidityProviderFee → swapFee

### DIFF
--- a/example/src/Publish.tsx
+++ b/example/src/Publish.tsx
@@ -36,7 +36,7 @@ export function Publish() {
       tokensToMint: 10,
       type: 'fixed',
       weightOnDataToken: '',
-      liquidityProviderFee: ''
+      swapFee: ''
     }
 
     const ddo = await publish(asset as Metadata, priceOptions, 'access')

--- a/src/hooks/usePublish/PriceOptions.ts
+++ b/src/hooks/usePublish/PriceOptions.ts
@@ -3,5 +3,5 @@ export interface PriceOptions {
   tokensToMint: number
   type: 'fixed' | 'dynamic' | string
   weightOnDataToken: string
-  liquidityProviderFee: string
+  swapFee: string
 }

--- a/src/hooks/usePublish/README.md
+++ b/src/hooks/usePublish/README.md
@@ -29,7 +29,7 @@ export default function MyComponent() {
     tokensToMint: 10,
     type: 'fixed',
     weightOnDataToken: '',
-    liquidityProviderFee: ''
+    swapFee: ''
   }
 
   async function handlePublish() {

--- a/src/hooks/usePublish/usePublish.ts
+++ b/src/hooks/usePublish/usePublish.ts
@@ -54,7 +54,7 @@ function usePublish(): UsePublish {
           dataTokenAddress,
           priceOptions.tokensToMint.toString(),
           priceOptions.weightOnDataToken,
-          priceOptions.liquidityProviderFee
+          priceOptions.swapFee
         )
         break
       }


### PR DESCRIPTION
Rename key to stay consistent with Balancer's own naming, and our pool methods.