### PR TITLE
fix publish

### DIFF
--- a/src/hooks/usePublish/usePublish.ts
+++ b/src/hooks/usePublish/usePublish.ts
@@ -1,15 +1,15 @@
-import { useState } from 'react'
-import { DDO, Metadata, Logger } from '@oceanprotocol/lib'
-import { useOcean } from '../../providers'
-import ProviderStatus from '../../providers/OceanProvider/ProviderStatus'
+import { DDO, Logger, Metadata } from '@oceanprotocol/lib'
 import {
   Service,
   ServiceComputePrivacy,
   ServiceType
 } from '@oceanprotocol/lib/dist/node/ddo/interfaces/Service'
-import { PriceOptions } from './PriceOptions'
-import { publishFeedback } from '../../utils'
+import { useState } from 'react'
 import { DataTokenOptions } from '.'
+import { useOcean } from '../../providers'
+import ProviderStatus from '../../providers/OceanProvider/ProviderStatus'
+import { publishFeedback } from '../../utils'
+import { PriceOptions } from './PriceOptions'
 
 interface UsePublish {
   publish: (
@@ -175,6 +175,7 @@ function usePublish(): UsePublish {
           asset,
           account,
           services,
+          undefined,
           dataTokenOptions?.cap,
           dataTokenOptions?.name,
           dataTokenOptions?.symbol


### PR DESCRIPTION
Based on new typings, `ocean.assets.create` has `dtAddress` as a parameter before the dataToken options.

<img width="576" alt="Screen Shot 2020-09-29 at 15 48 13" src="https://user-images.githubusercontent.com/90316/94567007-4eb25b80-026b-11eb-8e1a-367b15c3a445.png">
