### PR TITLE
use networkId instead of chainId

### DIFF
--- a/example/src/AllDdos.tsx
+++ b/example/src/AllDdos.tsx
@@ -7,7 +7,7 @@ import shortid from 'shortid'
 import { MetadataExample } from './MetadataExample'
 
 export function AllDdos() {
-  const { chainId, account, accountId, ocean } = useOcean()
+  const { networkId, account, accountId, ocean } = useOcean()
 
   const [ddos, setDdos] = useState<DDO[]>()
 
@@ -26,7 +26,7 @@ export function AllDdos() {
       setDdos(assets.results.slice(0, 4))
     }
     init()
-  }, [ocean, account, chainId, accountId])
+  }, [ocean, account, networkId, accountId])
 
   return (
     <>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1516,14 +1516,14 @@
       }
     },
     "@oceanprotocol/contracts": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@oceanprotocol/contracts/-/contracts-0.5.1.tgz",
-      "integrity": "sha512-bt5uwh79D759H6O4bAv+ycGdZQISFAxi65cqIygzA9hwsu29+GuOLwu1mxrzl2lVNLs6Emxo7TaDv0jAoyqnCg=="
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@oceanprotocol/contracts/-/contracts-0.5.2.tgz",
+      "integrity": "sha512-PTMeP8Ixe66F2YMUgVLibg9k7r2db85Syb66tWUpI+dGnt5KzW1SmQOsyVRjp3x8avRAyMFYaOodXp570jnsmQ=="
     },
     "@oceanprotocol/lib": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@oceanprotocol/lib/-/lib-0.5.2.tgz",
-      "integrity": "sha512-LCiQuae9cP+Hcu5rDbASBbmEwhxujm5Z49WtaKo2x+UtDAovjjXtNeSMw7WjyJAe+T/gOkHhzn92w0Cc9SUOQA==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@oceanprotocol/lib/-/lib-0.5.3.tgz",
+      "integrity": "sha512-LYKqgAuf5PNOiGr6Je6v8yupaFmFojiPtkl/gywlBhF/MsMn/PdKLvHRaNge5y69hoJVXfYYEpr0HzyHq9Mx5w==",
       "requires": {
         "@ethereum-navigator/navigator": "^0.5.0",
         "@oceanprotocol/contracts": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "dist/"
   ],
   "dependencies": {
-    "@oceanprotocol/lib": "^0.5.2",
+    "@oceanprotocol/lib": "^0.5.3",
     "axios": "^0.20.0",
     "decimal.js": "^10.2.1",
     "web3": "^1.3.0",

--- a/src/hooks/useMetadata/useMetadata.ts
+++ b/src/hooks/useMetadata/useMetadata.ts
@@ -17,7 +17,7 @@ interface UseMetadata {
 }
 
 function useMetadata(asset?: DID | string | DDO): UseMetadata {
-  const { ocean, status, accountId, chainId } = useOcean()
+  const { ocean, status, accountId, networkId } = useOcean()
   const [internalDdo, setDDO] = useState<DDO>()
   const [internalDid, setDID] = useState<DID | string>()
   const [metadata, setMetadata] = useState<Metadata>()
@@ -100,7 +100,7 @@ function useMetadata(asset?: DID | string | DDO): UseMetadata {
     return () => {
       clearInterval(interval)
     }
-  }, [accountId, chainId, internalDdo, getMetadata, getPrice])
+  }, [accountId, networkId, internalDdo, getMetadata, getPrice])
 
   return {
     ddo: internalDdo,

--- a/src/providers/OceanProvider/OceanProvider.tsx
+++ b/src/providers/OceanProvider/OceanProvider.tsx
@@ -28,7 +28,6 @@ interface OceanProviderValue {
   account: Account
   accountId: string
   balance: Balance
-  chainId: number | undefined
   networkId: number | undefined
   status: ProviderStatus
   connect: (config?: Config) => Promise<void>
@@ -51,7 +50,6 @@ function OceanProvider({
   const [web3Provider, setWeb3Provider] = useState<any | undefined>()
   const [ocean, setOcean] = useState<Ocean | undefined>()
   const [web3Modal, setWeb3Modal] = useState<Web3Modal>()
-  const [chainId, setChainId] = useState<number | undefined>()
   const [networkId, setNetworkId] = useState<number | undefined>()
   const [account, setAccount] = useState<Account | undefined>()
   const [accountId, setAccountId] = useState<string | undefined>()
@@ -92,10 +90,6 @@ function OceanProvider({
         const web3 = new Web3(provider)
         setWeb3(web3)
         Logger.log('Web3 created.', web3)
-
-        const chainId = web3 && (await web3.eth.getChainId())
-        setChainId(chainId)
-        Logger.log('chain id ', chainId)
 
         const networkId = web3 && (await web3.eth.net.getId())
         setNetworkId(networkId)
@@ -177,7 +171,6 @@ function OceanProvider({
           account,
           accountId,
           balance,
-          chainId,
           networkId,
           status,
           config,

--- a/src/providers/OceanProvider/OceanProvider.tsx
+++ b/src/providers/OceanProvider/OceanProvider.tsx
@@ -29,6 +29,7 @@ interface OceanProviderValue {
   accountId: string
   balance: Balance
   chainId: number | undefined
+  networkId: number | undefined
   status: ProviderStatus
   connect: (config?: Config) => Promise<void>
   logout: () => Promise<void>
@@ -51,6 +52,7 @@ function OceanProvider({
   const [ocean, setOcean] = useState<Ocean | undefined>()
   const [web3Modal, setWeb3Modal] = useState<Web3Modal>()
   const [chainId, setChainId] = useState<number | undefined>()
+  const [networkId, setNetworkId] = useState<number | undefined>()
   const [account, setAccount] = useState<Account | undefined>()
   const [accountId, setAccountId] = useState<string | undefined>()
   const [config, setConfig] = useState<Config>(initialConfig)
@@ -94,6 +96,10 @@ function OceanProvider({
         const chainId = web3 && (await web3.eth.getChainId())
         setChainId(chainId)
         Logger.log('chain id ', chainId)
+
+        const networkId = web3 && (await web3.eth.net.getId())
+        setNetworkId(networkId)
+        Logger.log('network id ', networkId)
 
         config.web3Provider = web3
         const ocean = await Ocean.getInstance(config)
@@ -172,6 +178,7 @@ function OceanProvider({
           accountId,
           balance,
           chainId,
+          networkId,
           status,
           config,
           connect,


### PR DESCRIPTION
Read out network ID for more control when working with locally running networks. In all the supported remote networks the network Id will equal the chain ID anyway, so should not have any influence for those networks.

On top of https://github.com/oceanprotocol/ocean-lib-js/pull/327