### PR TITLE
BestPrice updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1521,9 +1521,9 @@
       "integrity": "sha512-gJ8qQACJgxOPIrPE0OFQ09iYXBAisOGg56EmelQlsMUgp0yY0DKgBntDP83S/Ho1yBjGygqfxCjQrPH63hh/PA=="
     },
     "@oceanprotocol/lib": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@oceanprotocol/lib/-/lib-0.5.5.tgz",
-      "integrity": "sha512-TJTehUaQnFfNp0dJmw0t15+mpYbTkeF+RX4oc6D5FN7hmlhdvC8kfGf8yeHiqxI2Nb703foFLSSs38MWu/XEpg==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@oceanprotocol/lib/-/lib-0.5.6.tgz",
+      "integrity": "sha512-S8OU/FYjDJCKkx098GDT9LfxmTTe/gA8zv5fVMy7lRG1k5WFDsHHMplqZkU9mUGXg1aDDtt7KbctwxNdt7ZGFg==",
       "requires": {
         "@ethereum-navigator/navigator": "^0.5.0",
         "@oceanprotocol/contracts": "^0.5.3",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "dist/"
   ],
   "dependencies": {
-    "@oceanprotocol/lib": "^0.5.5",
+    "@oceanprotocol/lib": "^0.5.6",
     "axios": "^0.20.0",
     "decimal.js": "^10.2.1",
     "web3": "^1.3.0",

--- a/src/hooks/useMetadata/BestPrice.ts
+++ b/src/hooks/useMetadata/BestPrice.ts
@@ -1,5 +1,0 @@
-export default interface BestPrice {
-  type: 'pool' | 'exchange'
-  address: string
-  value: string
-}

--- a/src/hooks/useMetadata/Pool.ts
+++ b/src/hooks/useMetadata/Pool.ts
@@ -1,4 +1,6 @@
 export default interface Pool {
   address: string
-  price: string
+  price: number
+  ocean?: number
+  datatoken?: number
 }

--- a/src/hooks/useMetadata/index.ts
+++ b/src/hooks/useMetadata/index.ts
@@ -1,3 +1,2 @@
 export * from './useMetadata'
 export * from './Pool'
-export * from './BestPrice'

--- a/src/hooks/useMetadata/useMetadata.ts
+++ b/src/hooks/useMetadata/useMetadata.ts
@@ -1,10 +1,9 @@
 import { useState, useEffect, useCallback } from 'react'
-import { DID, DDO, Metadata, Logger } from '@oceanprotocol/lib'
+import { DID, DDO, Metadata, Logger, BestPrice } from '@oceanprotocol/lib'
 import { useOcean } from 'providers'
 import ProviderStatus from 'providers/OceanProvider/ProviderStatus'
 import { getBestDataTokenPrice } from 'utils/dtUtils'
 import { isDDO } from 'utils'
-import BestPrice from './BestPrice'
 
 interface UseMetadata {
   ddo: DDO | undefined
@@ -35,14 +34,10 @@ function useMetadata(asset?: DID | string | DDO): UseMetadata {
 
   const getPrice = useCallback(
     async (dataTokenAddress: string): Promise<BestPrice> => {
-      const price = await getBestDataTokenPrice(
-        ocean,
-        dataTokenAddress,
-        accountId
-      )
+      const price = await getBestDataTokenPrice(ocean, dataTokenAddress)
       return price
     },
-    [ocean, accountId]
+    [ocean]
   )
 
   const getMetadata = useCallback(async (ddo: DDO): Promise<Metadata> => {

--- a/src/hooks/useMetadata/useMetadata.ts
+++ b/src/hooks/useMetadata/useMetadata.ts
@@ -1,7 +1,13 @@
 import { useState, useEffect, useCallback } from 'react'
-import { DID, DDO, Metadata, Logger, BestPrice } from '@oceanprotocol/lib'
+import {
+  DID,
+  DDO,
+  Metadata,
+  Logger,
+  BestPrice,
+  MetadataStore
+} from '@oceanprotocol/lib'
 import { useOcean } from 'providers'
-import ProviderStatus from 'providers/OceanProvider/ProviderStatus'
 import { getBestDataTokenPrice } from 'utils/dtUtils'
 import { isDDO } from 'utils'
 
@@ -16,7 +22,7 @@ interface UseMetadata {
 }
 
 function useMetadata(asset?: DID | string | DDO): UseMetadata {
-  const { ocean, status, accountId, networkId } = useOcean()
+  const { ocean, accountId, networkId, config } = useOcean()
   const [internalDdo, setDDO] = useState<DDO>()
   const [internalDid, setDID] = useState<DID | string>()
   const [metadata, setMetadata] = useState<Metadata>()
@@ -25,11 +31,14 @@ function useMetadata(asset?: DID | string | DDO): UseMetadata {
   const [price, setPrice] = useState<BestPrice>()
 
   const getDDO = useCallback(
-    async (did: DID | string): Promise<DDO> => {
-      const ddo = await ocean.metadatastore.retrieveDDO(did)
+    async (did: DID | string): Promise<DDO | undefined> => {
+      if (!config.metadataStoreUri) return
+
+      const metadataStore = new MetadataStore(config.metadataStoreUri, Logger)
+      const ddo = await metadataStore.retrieveDDO(did)
       return ddo
     },
-    [ocean?.metadatastore]
+    [config.metadataStoreUri]
   )
 
   const getPrice = useCallback(
@@ -49,11 +58,9 @@ function useMetadata(asset?: DID | string | DDO): UseMetadata {
   // Get and set DDO based on passed DDO or DID
   //
   useEffect(() => {
-    if (!asset || !ocean || status !== ProviderStatus.CONNECTED) return
+    if (!asset) return
 
     async function init(): Promise<void> {
-      if (!asset) return
-
       if (isDDO(asset as string | DDO | DID)) {
         setDDO(asset as DDO)
         setDID((asset as DDO).id)
@@ -66,30 +73,34 @@ function useMetadata(asset?: DID | string | DDO): UseMetadata {
       }
     }
     init()
-  }, [ocean, status, asset, getDDO])
+  }, [asset, getDDO])
 
   //
-  // Get metadata for stored DDO
+  // Get metadata & price for stored DDO
   //
   useEffect(() => {
-    if (!accountId) return
-
     async function init(): Promise<void> {
       if (!internalDdo) return
+
+      // Set price from DDO first
+      setPrice(internalDdo.price)
 
       const metadata = await getMetadata(internalDdo)
       setMetadata(metadata)
       setTitle(metadata.main.name)
-      const price = await getPrice(internalDdo.dataToken)
-      price && setPrice(price)
       setIsLoaded(true)
+
+      if (!accountId) return
+      // Set price again, but from chain
+      const priceLive = await getPrice(internalDdo.dataToken)
+      priceLive && internalDdo.price !== priceLive && setPrice(priceLive)
     }
     init()
 
     const interval = setInterval(async () => {
-      if (!internalDdo) return
-      const price = await getPrice(internalDdo.dataToken)
-      price && setPrice(price)
+      if (!internalDdo || !accountId) return
+      const priceLive = await getPrice(internalDdo.dataToken)
+      priceLive && setPrice(priceLive)
     }, 10000)
 
     return () => {


### PR DESCRIPTION
Following https://github.com/oceanprotocol/ocean-lib-js/pull/340 & https://github.com/oceanprotocol/aquarius/pull/286

`price` returned from `useMetadata` is now set first from the new `ddo.price` object, and then fetches the price as before, and replaces the values. Also refactored to make sure there is no initialized `ocean` or `accountId` required to get that first `ddo.price`.

And with that, this is finally possible, showing a price without any wallet:

<img width="490" alt="Screen Shot 2020-10-08 at 13 43 02" src="https://user-images.githubusercontent.com/90316/95454052-32e63e00-096c-11eb-825b-9ccdf6e1b686.png">