### PR TITLE
pass through mpAddress

### DIFF
--- a/example/src/ConsumeDdo.tsx
+++ b/example/src/ConsumeDdo.tsx
@@ -9,7 +9,7 @@ import { useState } from 'react'
 import { useEffect } from 'react'
 
 export function ConsumeDdo() {
-  const { ocean } = useOcean()
+  const { ocean, accountId } = useOcean()
   const { consumeStepText, consume, consumeError } = useConsume()
   const { compute, computeStepText } = useCompute()
   const [did, setDid] = useState<string | undefined>()
@@ -22,7 +22,8 @@ export function ConsumeDdo() {
     if (!did) return
     const ddo = await ocean.assets.resolve(did)
 
-    await consume(did, ddo.dataToken, 'access')
+    // use own accountId for marketFeeAddress for testing purposes
+    await consume(did, ddo.dataToken, 'access', accountId)
   }
 
   const computeDid = async () => {

--- a/src/hooks/useCompute/useCompute.ts
+++ b/src/hooks/useCompute/useCompute.ts
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { useOcean } from 'providers'
 import { ComputeValue } from './ComputeOptions'
-import { Logger } from '@oceanprotocol/lib'
+import { Logger, ServiceCompute } from '@oceanprotocol/lib'
 import { MetadataAlgorithm } from '@oceanprotocol/lib/dist/node/ddo/interfaces/MetadataAlgorithm'
 import { ComputeJob } from '@oceanprotocol/lib/dist/node/ocean/interfaces/ComputeJob'
 import { checkAndBuyDT } from 'utils/dtUtils'
@@ -9,10 +9,11 @@ import { checkAndBuyDT } from 'utils/dtUtils'
 interface UseCompute {
   compute: (
     did: string,
-    computeService: any,
+    computeService: ServiceCompute,
     dataTokenAddress: string,
     algorithmRawCode: string,
-    computeContainer: ComputeValue
+    computeContainer: ComputeValue,
+    marketFeeAddress: string
   ) => Promise<ComputeJob | void>
   computeStep?: number
   computeStepText?: string
@@ -57,10 +58,11 @@ function useCompute(): UseCompute {
 
   async function compute(
     did: string,
-    computeService: any,
+    computeService: ServiceCompute,
     dataTokenAddress: string,
     algorithmRawCode: string,
-    computeContainer: ComputeValue
+    computeContainer: ComputeValue,
+    marketFeeAddress: string
   ): Promise<ComputeJob | void> {
     if (!ocean || !account) return
 
@@ -80,14 +82,16 @@ function useCompute(): UseCompute {
         accountId,
         did,
         computeService,
-        rawAlgorithmMeta
+        rawAlgorithmMeta,
+        marketFeeAddress
       )
       const tokenTransfer = await ocean.compute.order(
         accountId,
         did,
         computeService.index,
         undefined,
-        rawAlgorithmMeta
+        rawAlgorithmMeta,
+        marketFeeAddress
       )
 
       setStep(1)
@@ -108,7 +112,7 @@ function useCompute(): UseCompute {
         undefined,
         rawAlgorithmMeta,
         output,
-        computeService.index,
+        `${computeService.index}`,
         computeService.type
       )
       return response

--- a/src/hooks/useConsume/README.md
+++ b/src/hooks/useConsume/README.md
@@ -14,13 +14,13 @@ export default function MyComponent() {
   const { accountId } = useOcean()
 
   // Get metadata for this asset
-  const { title, price } = useMetadata(did)
+  const { title, price, ddo } = useMetadata(did)
 
   // Consume helpers
   const { consume, consumeStep } = useConsume()
 
   async function handleDownload() {
-    await consume(did)
+    await consume(did, ddo.dataToken, 'access')
   }
 
   return (

--- a/src/hooks/useConsume/useConsume.ts
+++ b/src/hooks/useConsume/useConsume.ts
@@ -8,7 +8,8 @@ interface UseConsume {
   consume: (
     did: DID | string,
     dataTokenAddress: string,
-    serviceType: ServiceType
+    serviceType: ServiceType,
+    marketFeeAddress: string
   ) => Promise<void>
   consumeStep?: number
   consumeStepText?: string
@@ -39,7 +40,8 @@ function useConsume(): UseConsume {
   async function consume(
     did: DID | string,
     dataTokenAddress: string,
-    serviceType: ServiceType = 'access'
+    serviceType: ServiceType = 'access',
+    marketFeeAddress: string
   ): Promise<void> {
     if (!ocean || !account || !accountId) return
     setIsLoading(true)
@@ -53,7 +55,9 @@ function useConsume(): UseConsume {
       const tokenTransfer = await ocean.assets.order(
         did as string,
         serviceType,
-        accountId
+        accountId,
+        undefined,
+        marketFeeAddress
       )
       Logger.log('order created', tokenTransfer)
       setStep(2)


### PR DESCRIPTION
Marketplace fee address was never passed through to `ocean.assets.order()` or `ocean.compute.order()`