### PR TITLE
bump ocean.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2593,9 +2593,9 @@
       "integrity": "sha512-yoGk4kpTy9E06OWusd3Fa/W3yjmFNKND/I92YtmrMnX0i3gm/kom/Z7XrRiAHVC8JVnM9Q79FojGLd2eOL4opg=="
     },
     "@oceanprotocol/lib": {
-      "version": "0.9.21",
-      "resolved": "https://registry.npmjs.org/@oceanprotocol/lib/-/lib-0.9.21.tgz",
-      "integrity": "sha512-Bo+xJeFXOMfqof0GA5B07wWkBJ9S/v646zrUGuVIZ7nmwnGR8ba5Sr3lznpz7JIvmIpSNsKkXXWwwsRtZeeA1w==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@oceanprotocol/lib/-/lib-0.10.0.tgz",
+      "integrity": "sha512-ibsdyCS3ROUMShznaSvThHuTaGxKXCMedZfkvkFY1iFJvUL8HgJ0V6kRINNZDamj8AxLjEI1uV1QA3UTB8qkJA==",
       "requires": {
         "@ethereum-navigator/navigator": "^0.5.2",
         "@oceanprotocol/contracts": "^0.5.8",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "dist/"
   ],
   "dependencies": {
-    "@oceanprotocol/lib": "^0.9.21",
+    "@oceanprotocol/lib": "^0.10.0",
     "axios": "^0.21.1",
     "decimal.js": "^10.2.1",
     "web3": "1.3.1",


### PR DESCRIPTION
bump to ocean.js `v0.10.0`. Breaking change if `ocean.assets.editMetadata` has been used from it, see https://github.com/oceanprotocol/ocean.js/blob/main/CHANGELOG.md