### PR TITLE
lib bump, publish update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2592,9 +2592,9 @@
       "integrity": "sha512-6GrBk1jy+zxjDjh2SPra06etrqdp8CB6RaZaTq2OQpK8dA2Dq91hqCbj+6eb21MlU8bDY3/atnxax9rgPgsxkA=="
     },
     "@oceanprotocol/lib": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/@oceanprotocol/lib/-/lib-0.11.4.tgz",
-      "integrity": "sha512-sYfbgsOmiF6RrSjeGCvKEXoLl2Q41wKuoWT5gAqy7IoyVjwDerx96kLdTZp33etMoQ0/MJRud0ZGL0sZwqfVWw==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@oceanprotocol/lib/-/lib-0.12.0.tgz",
+      "integrity": "sha512-bREJhiyQ1LlFdLY0WoZbelfH27R7PLi0pY+c3TiX3fYvDShfp5NCYkq0B8Wf4FjxUxd4BMJREwRNdOS416RYVA==",
       "requires": {
         "@ethereum-navigator/navigator": "^0.5.2",
         "@oceanprotocol/contracts": "^0.5.10",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "dist/"
   ],
   "dependencies": {
-    "@oceanprotocol/lib": "^0.11.4",
+    "@oceanprotocol/lib": "^0.12.0",
     "axios": "^0.21.1",
     "decimal.js": "^10.2.1",
     "web3": "1.3.4",

--- a/src/hooks/usePublish/usePublish.ts
+++ b/src/hooks/usePublish/usePublish.ts
@@ -25,7 +25,7 @@ interface UsePublish {
 }
 
 function usePublish(): UsePublish {
-  const { ocean, status, account } = useOcean()
+  const { ocean, status, account, accountId } = useOcean()
   const [isLoading, setIsLoading] = useState(false)
   const [publishStep, setPublishStep] = useState<number | undefined>()
   const [publishStepText, setPublishStepText] = useState<string | undefined>()
@@ -140,6 +140,8 @@ function usePublish(): UsePublish {
           providerUri
         )
         .next(setStep)
+
+      await ocean.assets.publishDdo(ddo, accountId)
       Logger.log('ddo created', ddo)
       await sleep(20000)
       setStep(7)


### PR DESCRIPTION
`usePublish` changed. `ocean.assets.create`  only creates the ddo now, to publish on chain `ocean.assets.publishDdo` is needed.
No updates needed when using `usePublish`